### PR TITLE
Fix dependency on packages with security problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies" :
   { "cron" : "1.0.9",
     "cfenv" : "1.0.0",
-    "yamljs" : "0.2.3"
+    "yamljs" : "0.3.0"
   },
   "engines": {
     "node": "0.12.x"


### PR DESCRIPTION
There's an upstream dependency on insecure versions of NPM packages, as discovered [via Snyk](https://snyk.io/test/github/18F/cg-cron?tab=issues).

It appears no one has ever worked on this aside from Ozzy, though @brittag was the last to make a (non-technical) commit to it. I don't even know if this breaks it... 🤷‍♂️ 